### PR TITLE
Window pos initialization fix. Store window pos in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 1.16
+- setting of initial window position is now done on game start, not postponed until entering main menu
+- last window position is now stored in config file and restored on game start
+
+## 1.15
+- fixed mouse cursor not showing up in GTA SA

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Originally created by maxorator as part of Maxo's Vehicle Loader for Vice City, 
 
 >* If SilentPatch is installed, you won't be able to move mouse cursor while in-game. Enter main menu before activating mouse cursor.
 
->* In San Andreas, mouse cursor is not visible.
-
 ----
 ## Credits
 * [maxorator](http://gtaforums.com/topic/477801-maxos-vehicle-loader/)


### PR DESCRIPTION
Currently game window is centered on screen, but it is implemented inside mouse handling function.
Result is that during the intro videos and splash screens window is placed at random position, then it is moved when main menu appears. 
Fixed by moving initial window position code into AdjustPresentParams function.

Added saving of user set window position into config file, so after game start it is same as last time user had it.

Added change log file